### PR TITLE
Date and time formats

### DIFF
--- a/dist/view.js
+++ b/dist/view.js
@@ -18,6 +18,7 @@ exports.compileView = compileView;
 exports.allResourcesLoaded = allResourcesLoaded;
 exports.vegaToVega = vegaToVega;
 exports.reactVirtualizedToReactVirtualized = reactVirtualizedToReactVirtualized;
+exports.normalizeDateAndTime = normalizeDateAndTime;
 
 var _lodash = require('lodash');
 
@@ -298,4 +299,43 @@ function reactVirtualizedToReactVirtualized(view) {
     rowCount: rowCount,
     columnWidth: columnWidth
   };
+}
+
+/**
+  * Ensure dates and times in resources are in ISO format.
+  * @param {resource}
+  * @return {resource} with formatted dates and times
+  */
+function normalizeDateAndTime(resource) {
+  if (resource._values) {
+    var dateFields = [],
+        timeFields = [],
+        dateTimeFields = [];
+
+    resource.schema.fields.forEach(function (field, idx) {
+      if (field.type === 'date') {
+        dateFields.push(idx);
+      } else if (field.type === 'time') {
+        timeFields.push(idx);
+      } else if (field.type === 'datetime') {
+        dateTimeFields.push(idx);
+      }
+    });
+
+    resource._values.forEach(function (entry) {
+      dateFields.forEach(function (fieldIdx) {
+        var date = entry[fieldIdx].toString();
+        date = new Date(date.substring(0, 28));
+        entry[fieldIdx] = date.toISOString().substring(0, 10);
+      });
+      timeFields.forEach(function (timeField) {
+        var time = entry[timeField].toISOString();
+        entry[timeField] = time.substring(11, 19);
+      });
+      dateTimeFields.forEach(function (dateTimeField) {
+        entry[dateTimeField] = entry[dateTimeField].toISOString();
+      });
+    });
+  }
+  return resource;
 }

--- a/lib/view.js
+++ b/lib/view.js
@@ -267,3 +267,43 @@ export function reactVirtualizedToReactVirtualized(view) {
     , columnWidth
   }
 }
+
+/**
+  * Ensure dates and times in resources are in ISO format.
+  * @param {resource}
+  * @return {resource} with formatted dates and times
+  */
+export function normalizeDateAndTime(resource) {
+  if(resource._values) {
+    let dateFields = []
+        , timeFields = []
+        , dateTimeFields = []
+
+    resource.schema.fields.forEach((field, idx) => {
+      if(field.type === 'date') {
+        dateFields.push(idx)
+      } else if (field.type === 'time') {
+        timeFields.push(idx)
+      } else if (field.type === 'datetime') {
+        dateTimeFields.push(idx)
+      }
+    })
+
+    resource._values.forEach((entry) => {
+      dateFields.forEach(fieldIdx => {
+        let date = entry[fieldIdx].toString()
+        date = new Date(date.substring(0, 28))
+        entry[fieldIdx] = date.toISOString().substring(0, 10)
+      })
+      timeFields.forEach(timeField => {
+        let time = entry[timeField].toISOString()
+        entry[timeField] = time.substring(11,19)
+      })
+      dateTimeFields.forEach(dateTimeField => {
+        entry[dateTimeField] = entry[dateTimeField].toISOString()
+      })
+    })
+
+  }
+  return resource
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "license": "MIT",
   "main": "./dist/view.js",
   "scripts": {
-    "build": "babel lib -d dist"
+    "build": "babel lib -d dist",
+    "test": "jest",
+    "watch": "jest --watch"
   },
   "dependencies": {
     "lodash": "^4.0.0"

--- a/test/lib/view.test.js
+++ b/test/lib/view.test.js
@@ -6,6 +6,12 @@ const mockTable1 = [
   , ['2014-01-05', 13.41, 14.00]
 ]
 
+const mockTable2 = [
+  [new Date('2014-01-02'), new Date('2014-01-02T05:00:00Z'), new Date('2014-01-02T05:00:00Z')]
+  , [new Date('2014-01-03'), new Date('2014-01-03T06:00:00Z'), new Date('2014-01-03T06:00:00Z')]
+  , [new Date('2014-01-06'), new Date('2014-01-06T07:00:00Z'), new Date('2014-01-06T07:00:00Z')]
+]
+
 const mockDescriptor = {
   name: 'demo-package'
   , resources: [
@@ -326,6 +332,28 @@ const plotlyExpected = {
   }
 }
 
+const mockResource = {
+  schema: {
+    fields: [
+      {
+        name: 'Date'
+        , type: 'date'
+        , description: ''
+      }
+      , {
+        name: 'Time'
+        , type: 'time'
+        , description: ''
+      }
+      , {
+        name: 'DateTime'
+        , type: 'datetime'
+        , description: ''
+      }
+    ]
+  },
+  _values: mockTable2
+}
 
 describe('Data Package View utils', () => {
   it('should generate Plotly spec - lines', () => {
@@ -690,5 +718,14 @@ describe('Data Package View utils - ReactVirtualized ', () => {
     }
 
     expect(outSpec).toEqual(expected)
+  })
+})
+
+describe('how normalizeDate works', () => {
+  it('should just work with dates, times and datetimes', () => {
+    let out = utils.normalizeDateAndTime(mockResource)
+    expect(out._values[0][0]).toEqual("2014-01-02")
+    expect(out._values[0][1]).toEqual("05:00:00")
+    expect(out._values[0][2]).toEqual("2014-01-02T05:00:00.000Z")
   })
 })


### PR DESCRIPTION
* function for converting JS date objects to:
  * ISO date (`yyyy-mm-dd`) if `type:"date"`
  * ISO time (`hh-mm-ss`) if `type:"time"`
  * ISO datetime (`yyyy-mm-ddThh-mm-ss.000Z`) if `type:"datetime"`
in schema.