### PR TITLE
[horizontal-bar-stack][m] adds horizontal-bar-stack to simple spec - closes #53

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -54,6 +54,10 @@ export function simpleToPlotly(view) {
     , bar: {
       type: 'bar'
     }
+    , "bar-horizontal-stack": {
+      type: 'bar'
+      , orientation: 'h'
+    }
     , scatter: lineSpec
     , 'lines-and-points': lineSpec
   }
@@ -63,14 +67,20 @@ export function simpleToPlotly(view) {
   if (rows.length < 1000) {
     rows = sortBy(rows, [view.spec.group])
   }
-  const xValues = rows.map(row => row[view.spec.group])
+  const groupValues = rows.map(row => row[view.spec.group])
   // generate the plotly series
   // { 'x': ..., 'y': ..., 'type': ...}
   const data = view.spec.series.map((serie) => {
-    const out = {
-      x: xValues
-      , y: rows.map(row => row[serie])
-      , name: serie
+
+    let out = {name: serie};
+
+    // horizontal graphs group by y values, vertical by x
+    if (view.spec.type === "bar-horizontal-stack") {
+      out.x = rows.map(row => row[serie])
+      out.y = groupValues
+    } else {
+      out.x = groupValues
+      out.y = rows.map(row => row[serie])
     }
     Object.assign(out, simpleGraphTypesToPlotly[view.spec.type])
     return out
@@ -84,10 +94,10 @@ export function simpleToPlotly(view) {
     // repeating dates as Plotly tries to have at least 10 ticks by default.
     // So if the range is less than 10d, we set `tickmode` property a `linear`
     // which handles displaying date ticks correctly:
-    const range = new Date(xValues[xValues.length - 1]) - new Date(xValues[0])
+    const range = new Date(groupValues[groupValues.length - 1]) - new Date(groupValues[0])
     shouldBeLinear = range < 864000001
   }
-  const plotlySpec = {
+  let plotlySpec = {
     data
     , layout: {
       title: view.title ? view.title : ''
@@ -116,7 +126,20 @@ export function simpleToPlotly(view) {
       , colorway: view.spec.colorway ? view.spec.colorway : ['#0a0a0a', '#ff8a0e', '#dadada', '#f4eb41', '#d10808', '#5bd107', '#2274A5', '#E83F6F', '#6E9887', '#3A435E', '#861388', '#9F8082']
     }
   }
+
+  // modify specs for horizontal graphs
+  if (view.spec.type === "bar-horizontal-stack") {
+    swap(plotlySpec.layout, 'xaxis', 'yaxis')
+    plotlySpec.layout['barmode'] = 'stack'
+  }
+
   return plotlySpec
+}
+
+function swap(object, property1, property2) {
+  let temp = object[property1]
+  object[property1] = object[property2]
+  object[property2] = temp
 }
 
 

--- a/test/lib/view.test.js
+++ b/test/lib/view.test.js
@@ -126,6 +126,18 @@ const mockViews = {
       , series: ['High']
     }
   }
+
+  , simpleBarHorizontalStack: {
+    name: 'simpleBarHorizontalStackName'
+    , title: 'simpleBarHorizontalStackTitle'
+    , specType: 'simple'
+    , spec: {
+      type: 'bar-horizontal-stack'
+      , group: 'Date'
+      , series: ['High']
+    }
+  }
+
   , vegaNoDataProperty1: {
     name: 'vega1'
     , resources: [0]
@@ -392,6 +404,52 @@ const plotlyExpected = {
       , colorway: ['#0a0a0a', '#ff8a0e', '#dadada', '#f4eb41', '#d10808', '#5bd107', '#2274A5', '#E83F6F', '#6E9887', '#3A435E', '#861388', '#9F8082']
     }
   }
+  , simpleBarHorizontalStack: {
+    data: [
+      {
+        y: [
+          '2014-01-01'
+          , '2014-01-02'
+          , '2014-01-05'
+        ]
+        , x: [
+          14.59
+          , 14.22
+          , 14
+        ]
+        , name: 'High'
+        , type: 'bar'
+        , orientation: 'h'
+      }
+    ]
+    , layout: {
+      title: 'simpleBarHorizontalStackTitle'
+      , barmode: 'stack'
+      , height: 450
+      , yaxis: {
+        title: 'Date'
+        , tickformat: "%e %b %Y"
+        , type: 'date'
+        , tickmode: 'linear'
+        , ticksuffix: ''
+      }
+      , xaxis: {
+        title: 'High'
+        , ticksuffix: ''
+      }
+      , font: {
+        family: "\"Open Sans\", verdana, arial, sans-serif"
+        , size: 12
+        , color: "rgb(169, 169, 169)"
+      }
+      , titlefont: {
+        family: "\"Open Sans\", verdana, arial, sans-serif"
+        , size: 17
+        , color: "rgb(76, 76, 76)"
+      }
+      , colorway: ['#0a0a0a', '#ff8a0e', '#dadada', '#f4eb41', '#d10808', '#5bd107', '#2274A5', '#E83F6F', '#6E9887', '#3A435E', '#861388', '#9F8082']
+    }
+  }
 }
 
 const mockResource = {
@@ -432,6 +490,11 @@ describe('Data Package View utils', () => {
     const view = utils.compileView(mockViews.simpleBar, mockDescriptor)
     const plotlySpec = utils.simpleToPlotly(view)
     expect(plotlySpec).toEqual(plotlyExpected.simpleBar)
+  })
+  it('should generate Plotly spec - horizontal bar', () => {
+    const view = utils.compileView(mockViews.simpleBarHorizontalStack, mockDescriptor)
+    const plotlySpec = utils.simpleToPlotly(view)
+    expect(plotlySpec).toEqual(plotlyExpected.simpleBarHorizontalStack)
   })
 })
 


### PR DESCRIPTION
Because the spec also adds `barmode: 'stack'` property I named the type "bar-horizontal-stack".