### PR TITLE
[plotlyToPlotly][m] adds the utility function to map data from resources property to plotly format - closes #55

### DIFF
--- a/dist/view.js
+++ b/dist/view.js
@@ -355,6 +355,17 @@ function vegaToVega(view) {
   }
 }
 
+function isHorizontal(plotlyGraphSpec) {
+  if (plotlyGraphSpec.data) {
+    if (plotlyGraphSpec.data.length > 0) {
+      if (plotlyGraphSpec.data[0].orientation) {
+        return plotlyGraphSpec.data[0].orientation === 'h';
+      }
+    }
+  }
+  return false;
+}
+
 /**
  * Prepare Plotly spec
  * @param {view} compiled view descriptor
@@ -373,17 +384,20 @@ function plotlyToPlotly(view) {
   var groupAndSeriesDefinedTraces = [];
   if (view.spec.group && view.spec.series) {
     // generate the plotly data series from `group` and `series`
-    // { 'x': ..., 'y': ..., 'name': ...}
+    // { 'x': ..., 'y': ...}
     groupAndSeriesDefinedTraces = view.spec.series.map(function (seriesColumn) {
-      var trace = {
-        // TODO: change x and y for horizontal graphs
-        x: groupValues,
-        y: rows.map(function (row) {
+      var trace = {};
+      if (isHorizontal(view.spec)) {
+        trace['x'] = rows.map(function (row) {
           return row[seriesColumn];
-        })
-        // TODO: think about names
-        // , name: seriesColumn
-      };
+        });
+        trace['y'] = groupValues;
+      } else {
+        trace['x'] = groupValues;
+        trace['y'] = rows.map(function (row) {
+          return row[seriesColumn];
+        });
+      }
       return trace;
     });
   }

--- a/lib/view.js
+++ b/lib/view.js
@@ -318,6 +318,27 @@ export function vegaToVega(view) {
   }
 }
 
+/**
+ * Prepare Plotly spec
+ * @param {view} compiled view descriptor
+ * @return {Object} plotlySpec - full spec with data values
+ */
+export function plotlyToPlotly(view) {
+  let plotlySpec = Object.assign({}, view.spec)
+  let loaded = allResourcesLoaded(view.resources)
+
+  if (!plotlySpec.data) {
+    plotlySpec.data = {}
+  }
+
+  if (loaded) {
+
+    // TODO: implement
+
+    return plotlySpec
+  }
+}
+
 export function reactVirtualizedToReactVirtualized(view) {
   const headers = view.resources[0].schema.fields.map(field => field.name)
     , rowsAsObjects = true

--- a/lib/view.js
+++ b/lib/view.js
@@ -318,6 +318,17 @@ export function vegaToVega(view) {
   }
 }
 
+function isHorizontal(plotlyGraphSpec) {
+  if (plotlyGraphSpec.data) {
+    if (plotlyGraphSpec.data.length > 0) {
+      if (plotlyGraphSpec.data[0].orientation) {
+        return plotlyGraphSpec.data[0].orientation === 'h'
+      }
+    }
+  }
+  return false
+}
+
 /**
  * Prepare Plotly spec
  * @param {view} compiled view descriptor
@@ -334,14 +345,15 @@ export function plotlyToPlotly(view) {
   let groupAndSeriesDefinedTraces = [];
   if (view.spec.group && view.spec.series) {
     // generate the plotly data series from `group` and `series`
-    // { 'x': ..., 'y': ..., 'name': ...}
+    // { 'x': ..., 'y': ...}
     groupAndSeriesDefinedTraces = view.spec.series.map((seriesColumn) => {
-      let trace = {
-        // TODO: change x and y for horizontal graphs
-        x: groupValues
-        , y: rows.map(row => row[seriesColumn])
-        // TODO: think about names
-        // , name: seriesColumn
+      let trace = {}
+      if (isHorizontal(view.spec)) {
+        trace['x'] = rows.map(row => row[seriesColumn])
+        trace['y'] = groupValues
+      } else {
+        trace['x'] = groupValues
+        trace['y'] = rows.map(row => row[seriesColumn])
       }
       return trace
     })

--- a/lib/view.js
+++ b/lib/view.js
@@ -325,19 +325,46 @@ export function vegaToVega(view) {
  */
 export function plotlyToPlotly(view) {
   let plotlySpec = Object.assign({}, view.spec)
-  let loaded = allResourcesLoaded(view.resources)
+
+  const rowsAsObjects = true
+  let rows = getResourceCachedValues(view.resources[0], rowsAsObjects)
+  const groupValues = rows.map(row => row[view.spec.group])
+
+  // In Plotly spec each data entry is called a trace
+  let groupAndSeriesDefinedTraces = [];
+  if (view.spec.group && view.spec.series) {
+    // generate the plotly data series from `group` and `series`
+    // { 'x': ..., 'y': ..., 'name': ...}
+    groupAndSeriesDefinedTraces = view.spec.series.map((seriesColumn) => {
+      let trace = {
+        // TODO: change x and y for horizontal graphs
+        x: groupValues
+        , y: rows.map(row => row[seriesColumn])
+        // TODO: think about names
+        // , name: seriesColumn
+      }
+      return trace
+    })
+  }
 
   if (!plotlySpec.data) {
-    plotlySpec.data = {}
+    plotlySpec.data = groupAndSeriesDefinedTraces;
+  } else {
+    // plotlySpec.data can contain layout information 
+    // according to Plotly specification
+    // even if x and y values are specified separately 
+    // (in `group` and `series`)
+    for (let i = 0; i < plotlySpec.data.length; i++) {
+      plotlySpec.data[i] = Object.assign(plotlySpec.data[i], groupAndSeriesDefinedTraces[i])
+    }
   }
 
-  if (loaded) {
+  delete plotlySpec.group
+  delete plotlySpec.series
 
-    // TODO: implement
-
-    return plotlySpec
-  }
+  return plotlySpec
 }
+
 
 export function reactVirtualizedToReactVirtualized(view) {
   const headers = view.resources[0].schema.fields.map(field => field.name)

--- a/test/lib/view.test.js
+++ b/test/lib/view.test.js
@@ -177,6 +177,124 @@ const mockViews = {
       ]
     }
   }
+  , plotlyWithNoData: {
+    name: 'plotly1'
+    , resources: [0]
+    , specType: 'plotly'
+    , spec: {
+      layout: {
+        title: "Plotly Layout Title"
+        , height: 450
+        , xaxis: {
+          title: 'Date'
+          , tickformat: "%e %b %Y"
+          , type: 'date'
+          , tickmode: 'linear'
+          , ticksuffix: ''
+        }
+        , yaxis: {
+          title: 'High',
+          ticksuffix: ''
+        }
+        , font: {
+          family: "\"Open Sans\", verdana, arial, sans-serif"
+          , size: 12
+          , color: "rgb(169, 169, 169)"
+        }
+        , titlefont: {
+          family: "\"Open Sans\", verdana, arial, sans-serif"
+          , size: 17
+          , color: "rgb(76, 76, 76)"
+        }
+      }
+    }
+  }
+  , plotlyWithDataPropertyButNoData: {
+    name: 'plotly1'
+    , resources: [0]
+    , specType: 'plotly'
+    , spec: {
+      data: [
+        {
+          type: 'scatter'
+          , mode: 'lines'
+          , line: { width: 1.5, shape: 'spline', dash: 'solid' }
+          , name: 'High'
+        }
+      ]
+      , layout: {
+        title: "Plotly Layout Title"
+        , height: 450
+        , xaxis: {
+          title: 'Date'
+          , tickformat: "%e %b %Y"
+          , type: 'date'
+          , tickmode: 'linear'
+          , ticksuffix: ''
+        }
+        , yaxis: {
+          title: 'High',
+          ticksuffix: ''
+        }
+        , font: {
+          family: "\"Open Sans\", verdana, arial, sans-serif"
+          , size: 12
+          , color: "rgb(169, 169, 169)"
+        }
+        , titlefont: {
+          family: "\"Open Sans\", verdana, arial, sans-serif"
+          , size: 17
+          , color: "rgb(76, 76, 76)"
+        }
+      }
+    }
+  }
+  , plotlyWithData: {
+    name: 'plotly1'
+    , resources: [0]
+    , specType: 'plotly'
+    , spec: {
+      layout: {
+        data: [
+          {
+            x: [
+              '2014-01-01'
+              , '2014-01-02'
+              , '2014-01-05'
+            ]
+            , y: [
+              14.59
+              , 14.22
+              , 14
+            ]
+          }
+        ]
+        , title: "Plotly Layout Title"
+        , height: 450
+        , xaxis: {
+          title: 'Date'
+          , tickformat: "%e %b %Y"
+          , type: 'date'
+          , tickmode: 'linear'
+          , ticksuffix: ''
+        }
+        , yaxis: {
+          title: 'High',
+          ticksuffix: ''
+        }
+        , font: {
+          family: "\"Open Sans\", verdana, arial, sans-serif"
+          , size: 12
+          , color: "rgb(169, 169, 169)"
+        }
+        , titlefont: {
+          family: "\"Open Sans\", verdana, arial, sans-serif"
+          , size: 17
+          , color: "rgb(76, 76, 76)"
+        }
+      }
+    }
+  }
 }
 
 const vegaExpected = {
@@ -390,6 +508,92 @@ const plotlyExpected = {
         , color: "rgb(76, 76, 76)"
       }
       , colorway: ['#0a0a0a', '#ff8a0e', '#dadada', '#f4eb41', '#d10808', '#5bd107', '#2274A5', '#E83F6F', '#6E9887', '#3A435E', '#861388', '#9F8082']
+    }
+  }
+  , plotlyWithNoData: {
+    data: [
+      {
+        x: [
+          '2014-01-01'
+          , '2014-01-02'
+          , '2014-01-05'
+        ]
+        , y: [
+          14.59
+          , 14.22
+          , 14
+        ]
+      }
+    ]
+    , layout: {
+      title: "Plotly Layout Title"
+      , height: 450
+      , xaxis: {
+        title: 'Date'
+        , tickformat: "%e %b %Y"
+        , type: 'date'
+        , tickmode: 'linear'
+        , ticksuffix: ''
+      }
+      , yaxis: {
+        title: 'High',
+        ticksuffix: ''
+      }
+      , font: {
+        family: "\"Open Sans\", verdana, arial, sans-serif"
+        , size: 12
+        , color: "rgb(169, 169, 169)"
+      }
+      , titlefont: {
+        family: "\"Open Sans\", verdana, arial, sans-serif"
+        , size: 17
+        , color: "rgb(76, 76, 76)"
+      }
+    }
+  }
+  , plotlyWithDataPropertyButNoData: {
+    data: [
+      {
+        x: [
+          '2014-01-01'
+          , '2014-01-02'
+          , '2014-01-05'
+        ]
+        , y: [
+          14.59
+          , 14.22
+          , 14
+        ]
+        , type: 'scatter'
+        , mode: 'lines'
+        , line: { width: 1.5, shape: 'spline', dash: 'solid' }
+        , name: 'High'
+      }
+    ]
+    , layout: {
+      title: "Plotly Layout Title"
+      , height: 450
+      , xaxis: {
+        title: 'Date'
+        , tickformat: "%e %b %Y"
+        , type: 'date'
+        , tickmode: 'linear'
+        , ticksuffix: ''
+      }
+      , yaxis: {
+        title: 'High',
+        ticksuffix: ''
+      }
+      , font: {
+        family: "\"Open Sans\", verdana, arial, sans-serif"
+        , size: 12
+        , color: "rgb(169, 169, 169)"
+      }
+      , titlefont: {
+        family: "\"Open Sans\", verdana, arial, sans-serif"
+        , size: 17
+        , color: "rgb(76, 76, 76)"
+      }
     }
   }
 }
@@ -754,6 +958,29 @@ describe('vegaToVega function', () => {
     let compiledView = utils.compileView(mockViews.vegaWithDataProperty2, mockDescriptor)
     const vegaSpec = utils.vegaToVega(compiledView)
     expect(vegaSpec).toEqual(vegaExpected.vegaWithDataProperty2)
+  })
+})
+
+describe('plotlyToPlotly function', () => {
+  it('should work with no data in plotly spec', () => {
+    let compiledView = utils.compileView(mockViews.plotlyWithNoData, mockDescriptor)
+    const plotlySpec = utils.plotlyToPlotly(compiledView)
+    expect(plotlySpec).toEqual(plotlyExpected.plotlyWithNoData)
+  })
+
+  it(`
+  should work with data property which contains no data
+   - it describes how the data is presented too
+  `, () => {
+    let compiledView = utils.compileView(mockViews.plotlyWithDataPropertyButNoData, mockDescriptor)
+    const plotlySpec = utils.plotlyToPlotly(compiledView)
+    expect(plotlySpec).toEqual(plotlyExpected.plotlyWithDataPropertyButNoData)
+  })
+
+  it('should work with data in the data property', () => {
+    let compiledView = utils.compileView(mockViews.plotlyWithData, mockDescriptor)
+    const plotlySpec = utils.plotlyToPlotly(compiledView)
+    expect(plotlySpec).toEqual(plotlyExpected.plotlyWithNoData)
   })
 })
 

--- a/test/lib/view.test.js
+++ b/test/lib/view.test.js
@@ -298,6 +298,46 @@ const mockViews = {
         }
       }
     }
+  },
+  plotlyHorizontal: {
+    name: 'plotly1'
+    , resources: [0]
+    , specType: 'plotly'
+    , spec: {
+      group: 'Date'
+      , series: ['High']
+      , data: [
+        {
+          type: 'bar'
+          , orientation: 'h'
+        }
+      ]
+      , layout: {
+        title: "Plotly Layout Title"
+        , height: 450
+        , yaxis: {
+          title: 'Date'
+          , tickformat: "%e %b %Y"
+          , type: 'date'
+          , tickmode: 'linear'
+          , ticksuffix: ''
+        }
+        , xaxis: {
+          title: 'High',
+          ticksuffix: ''
+        }
+        , font: {
+          family: "\"Open Sans\", verdana, arial, sans-serif"
+          , size: 12
+          , color: "rgb(169, 169, 169)"
+        }
+        , titlefont: {
+          family: "\"Open Sans\", verdana, arial, sans-serif"
+          , size: 17
+          , color: "rgb(76, 76, 76)"
+        }
+      }
+    }
   }
 }
 
@@ -585,6 +625,49 @@ const plotlyExpected = {
         , ticksuffix: ''
       }
       , yaxis: {
+        title: 'High',
+        ticksuffix: ''
+      }
+      , font: {
+        family: "\"Open Sans\", verdana, arial, sans-serif"
+        , size: 12
+        , color: "rgb(169, 169, 169)"
+      }
+      , titlefont: {
+        family: "\"Open Sans\", verdana, arial, sans-serif"
+        , size: 17
+        , color: "rgb(76, 76, 76)"
+      }
+    }
+  }
+  , plotlyHorizontal: {
+    data: [
+      {
+        y: [
+          '2014-01-01'
+          , '2014-01-02'
+          , '2014-01-05'
+        ]
+        , x: [
+          14.59
+          , 14.22
+          , 14
+        ]
+        , type: 'bar'
+        , orientation: 'h'
+      }
+    ]
+    , layout: {
+      title: "Plotly Layout Title"
+      , height: 450
+      , yaxis: {
+        title: 'Date'
+        , tickformat: "%e %b %Y"
+        , type: 'date'
+        , tickmode: 'linear'
+        , ticksuffix: ''
+      }
+      , xaxis: {
         title: 'High',
         ticksuffix: ''
       }
@@ -985,6 +1068,12 @@ describe('plotlyToPlotly function', () => {
     let compiledView = utils.compileView(mockViews.plotlyWithData, mockDescriptor)
     const plotlySpec = utils.plotlyToPlotly(compiledView)
     expect(plotlySpec).toEqual(plotlyExpected.plotlyWithNoData)
+  })
+
+  it('should map `group` to `y` and `series` to `x` in horizontal graphs', () => {
+    let compiledView = utils.compileView(mockViews.plotlyHorizontal, mockDescriptor)
+    const plotlySpec = utils.plotlyToPlotly(compiledView)
+    expect(plotlySpec).toEqual(plotlyExpected.plotlyHorizontal)
   })
 })
 

--- a/test/lib/view.test.js
+++ b/test/lib/view.test.js
@@ -182,7 +182,9 @@ const mockViews = {
     , resources: [0]
     , specType: 'plotly'
     , spec: {
-      layout: {
+      group: 'Date'
+      , series: ['High']
+      , layout: {
         title: "Plotly Layout Title"
         , height: 450
         , xaxis: {
@@ -214,7 +216,9 @@ const mockViews = {
     , resources: [0]
     , specType: 'plotly'
     , spec: {
-      data: [
+      group: 'Date'
+      , series: ['High']
+      , data: [
         {
           type: 'scatter'
           , mode: 'lines'
@@ -254,22 +258,22 @@ const mockViews = {
     , resources: [0]
     , specType: 'plotly'
     , spec: {
-      layout: {
-        data: [
-          {
-            x: [
-              '2014-01-01'
-              , '2014-01-02'
-              , '2014-01-05'
-            ]
-            , y: [
-              14.59
-              , 14.22
-              , 14
-            ]
-          }
-        ]
-        , title: "Plotly Layout Title"
+      data: [
+        {
+          x: [
+            '2014-01-01'
+            , '2014-01-02'
+            , '2014-01-05'
+          ]
+          , y: [
+            14.59
+            , 14.22
+            , 14
+          ]
+        }
+      ]
+      , layout: {
+        title: "Plotly Layout Title"
         , height: 450
         , xaxis: {
           title: 'Date'


### PR DESCRIPTION
`group` and `series` are not moved to `data`, see https://github.com/frictionlessdata/datapackage-render-js/issues/55#issuecomment-560283074